### PR TITLE
feat: password visibility toggle

### DIFF
--- a/src/app/(app)/settings/account/page.tsx
+++ b/src/app/(app)/settings/account/page.tsx
@@ -1,17 +1,18 @@
 "use client";
 
+import { SubmitHandler, useForm } from "react-hook-form";
+
 import Avatar from "@/components/avatar";
 import Input from "@/components/input";
 import Label from "@/components/label";
 import SettingsWrapper from "@/components/settings-wrapper";
+import clsx from "clsx";
+import { firstLastName } from "@/lib/utils";
+import { twMerge } from "tailwind-merge";
 import { useChangePassword } from "@/lib/mutations/session";
 import { useGetUserInfo } from "@/lib/queries/session";
-import { firstLastName } from "@/lib/utils";
-import { zodResolver } from "@hookform/resolvers/zod";
-import clsx from "clsx";
-import { SubmitHandler, useForm } from "react-hook-form";
-import { twMerge } from "tailwind-merge";
 import z from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 interface IInputLineProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label: string;

--- a/src/app/auth/forgot_password/[token]/page.tsx
+++ b/src/app/auth/forgot_password/[token]/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
+import { SubmitHandler, useForm } from "react-hook-form";
+
+import Image from "next/image";
 import Input from "@/components/input";
 import Label from "@/components/label";
-import { useResetPassword } from "@/lib/mutations/session";
-import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { SubmitHandler, useForm } from "react-hook-form";
+import { useResetPassword } from "@/lib/mutations/session";
 import z from "zod";
-import Image from "next/image";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 const formSchema = z
   .object({
@@ -128,6 +129,7 @@ export default function ResetPassword() {
                       })}
                       className="bg-dark/5 border-0 placeholder:text-black/50"
                       type="password"
+                      hideable
                       placeholder="Password"
                       id="password"
                     />
@@ -146,6 +148,7 @@ export default function ResetPassword() {
                       {...register("password_confirmation", { required: true })}
                       className="bg-dark/5 border-0 placeholder:text-black/50"
                       type="password"
+                      hideable
                       placeholder="Confirm Password"
                       id="password_confirmation"
                     />

--- a/src/app/auth/sign_in/page.tsx
+++ b/src/app/auth/sign_in/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
+import { SubmitHandler, useForm } from "react-hook-form";
+
+import Image from "next/image";
 import Input from "@/components/input";
 import Label from "@/components/label";
-import { useSignIn } from "@/lib/mutations/session";
-import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { SubmitHandler, useForm } from "react-hook-form";
+import { useSignIn } from "@/lib/mutations/session";
 import z from "zod";
-import Image from "next/image";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 const formSchema = z.object({
   email: z.email(),
@@ -104,6 +105,7 @@ export default function SignIn() {
                   className="bg-dark/5 border-0 placeholder:text-black/50"
                   type="password"
                   placeholder="Password"
+                  hideable
                 />
                 <span className="text-danger pl-2">
                   {errors.password?.message}

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -1,8 +1,10 @@
 import clsx from "clsx";
 import { twMerge } from "tailwind-merge";
+import { useState } from "react";
 
 interface IInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   center_text?: boolean;
+  hideable?: boolean;
 }
 
 export default function Input({
@@ -12,24 +14,47 @@ export default function Input({
   center_text,
   min,
   max,
+  hideable,
   ...rest
 }: IInputProps) {
   const textAlignment = center_text ? "text-center" : "text-left";
 
+  const [mutType, setMutType] = useState(type);
+
   return (
-    <input
-      type={type}
-      value={value}
+    <div
       className={twMerge(
         clsx(
           className,
           textAlignment,
-          "rounded-xl border border-black/10 px-2 py-1.5 text-black outline-none placeholder:text-black/30 invalid:border-red-500 invalid:text-red-600 md:px-3 md:py-2.5",
+          "flex items-center rounded-xl border border-black/10 px-2 py-1.5 text-black outline-none md:px-3 md:py-2.5",
         ),
       )}
-      min={type === "number" ? min : undefined}
-      max={type === "number" ? max : undefined}
-      {...rest}
-    />
+    >
+      <input
+        type={mutType}
+        value={value}
+        className={twMerge(
+          clsx(
+            className,
+            textAlignment,
+            "flex-1 bg-transparent text-black outline-none placeholder:text-black/30 invalid:border-red-500 invalid:text-red-600",
+          ),
+        )}
+        min={type === "number" ? min : undefined}
+        max={type === "number" ? max : undefined}
+        {...rest}
+      />
+      {hideable && (
+        <span
+          className="material-symbols-outlined ml-2 cursor-pointer text-xl text-black/50 hover:text-black"
+          onClick={() =>
+            mutType === "password" ? setMutType("text") : setMutType("password")
+          }
+        >
+          {mutType === "password" ? "visibility" : "visibility_off"}
+        </span>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
Adds a hideable prop to the input component and implements a password visibility toggle with aligned icon. (and works properly with bitwarden :pray:)

### Example

**Visible password ↓**
<img width="497" height="84" alt="image" src="https://github.com/user-attachments/assets/0156d384-de93-4411-b049-2ead70aa4ba1" />

**Hidden password ↓**
<img width="497" height="84" alt="image" src="https://github.com/user-attachments/assets/914c281d-7ed2-4685-8d84-e1c47d8447a9" />



